### PR TITLE
Fix EPUB validity, image paths, math rendering, and upgrade all deps

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,12 +31,6 @@ def main():
         help='Path to output directory (default: directory named after PDF)'
     )
     parser.add_argument(
-        '--batch-multiplier',
-        type=int,
-        default=2,
-        help='Multiplier for batch size (higher uses more memory but processes faster)'
-    )
-    parser.add_argument(
         '--max-pages',
         type=int,
         default=None,
@@ -47,12 +41,6 @@ def main():
         type=int,
         default=None,
         help='Page number to start from'
-    )
-    parser.add_argument(
-        '--langs',
-        type=str,
-        default=None,
-        help='Comma-separated list of languages in the document'
     )
     parser.add_argument(
         '--skip-epub',
@@ -100,10 +88,8 @@ def main():
                 pdf2md.convert_pdf(
                     str(pdf_path),
                     markdown_dir,
-                    args.batch_multiplier,
                     args.max_pages,
                     args.start_page,
-                    args.langs
                 )
             
             # Convert Markdown to EPUB unless skipped

--- a/modules/mark2epub.py
+++ b/modules/mark2epub.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 import subprocess
 from typing import Dict, Optional, Tuple
 from urllib.parse import quote
+from xml.sax.saxutils import escape as xml_escape
 import latex2mathml.converter
 
 def get_user_input(prompt: str, default: str = "") -> str:
@@ -75,16 +76,15 @@ def review_markdown(markdown_path: Path) -> tuple[bool, str]:
         else:
             print("Please enter 'y' or 'n'")
 
-def find_image_case_insensitive(images_dir: Path, name: str) -> Optional[Path]:
-    """Find an image file case-insensitively. Returns the actual Path or None."""
-    name_lower = name.lower()
+def build_image_lookup(images_dir: Path) -> dict:
+    """Build a {lowercase_name: actual_path} map for O(1) case-insensitive lookups."""
+    lookup = {}
     try:
         for entry in images_dir.iterdir():
-            if entry.name.lower() == name_lower:
-                return entry
+            lookup[entry.name.lower()] = entry
     except FileNotFoundError:
         pass
-    return None
+    return lookup
 
 def process_markdown_for_images(markdown_text: str, work_dir: Path) -> tuple[str, list[str]]:
     """Process markdown content to find image references."""
@@ -92,13 +92,13 @@ def process_markdown_for_images(markdown_text: str, work_dir: Path) -> tuple[str
     images_found = []
     modified_text = markdown_text
     images_dir = work_dir / 'images'
+    lookup = build_image_lookup(images_dir)
 
     for match in re.finditer(image_pattern, markdown_text):
         alt_text, image_path = match.groups()
-        image_path = image_path.strip()
-        img_path = Path(image_path)
+        img_path = Path(image_path.strip())
 
-        actual = find_image_case_insensitive(images_dir, img_path.name)
+        actual = lookup.get(img_path.name.lower())
         if actual is not None:
             images_found.append(actual.name)
             new_ref = f'![{alt_text}](images/{actual.name})'
@@ -230,7 +230,7 @@ def get_packageOPF_XML(md_filenames=[], image_filenames=[], css_filenames=[], de
     for i,image_filename in enumerate(image_filenames):
         x = doc.createElement('item')
         x.setAttribute('id',"image-{:05d}".format(i))
-        x.setAttribute('href',"images/{}".format(image_filename))
+        x.setAttribute('href', "images/{}".format(quote(image_filename)))
         if "gif" in image_filename:
             x.setAttribute('media-type',"image/gif")
         elif "jpg" in image_filename:
@@ -367,12 +367,12 @@ def get_TOCNCX_XML(markdown_filenames, uid="", title=""):
     toc_ncx = """<?xml version="1.0" encoding="UTF-8"?>\n"""
     toc_ncx += """<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" xml:lang="en" version="2005-1">\n"""
     toc_ncx += """<head>\n"""
-    toc_ncx += """<meta name="dtb:uid" content="{}"/>\n""".format(uid)
+    toc_ncx += """<meta name="dtb:uid" content="{}"/>\n""".format(xml_escape(uid))
     toc_ncx += """<meta name="dtb:depth" content="1"/>\n"""
     toc_ncx += """<meta name="dtb:totalPageCount" content="0"/>\n"""
     toc_ncx += """<meta name="dtb:maxPageNumber" content="0"/>\n"""
     toc_ncx += """</head>\n"""
-    toc_ncx += """<docTitle><text>{}</text></docTitle>\n""".format(title)
+    toc_ncx += """<docTitle><text>{}</text></docTitle>\n""".format(xml_escape(title))
     toc_ncx += """<navMap>\n"""
     for i,md_filename in enumerate(markdown_filenames):
         stem = md_filename.split(".")[0]
@@ -386,29 +386,49 @@ def get_TOCNCX_XML(markdown_filenames, uid="", title=""):
     return toc_ncx
 
 def convert_math_to_mathml(html_text: str) -> str:
-    """Replace LaTeX math expressions in HTML with inline MathML."""
-    # Display math: $$...$$
-    def replace_display(m):
-        latex = m.group(1)
-        try:
-            mathml = latex2mathml.converter.convert(latex)
-            # Wrap in a block-level span so readers treat it as display math
-            return f'<div class="math-display">{mathml}</div>'
-        except Exception:
-            return m.group(0)
+    """Replace LaTeX math expressions in HTML with MathML, skipping code blocks."""
+    # Mask <pre>/<code> blocks so their $ delimiters are never treated as math
+    placeholders = {}
+    counter = [0]
 
-    # Inline math: $...$  (not preceded/followed by another $)
+    def mask(m):
+        key = f"\x00MASK{counter[0]}\x00"
+        counter[0] += 1
+        placeholders[key] = m.group(0)
+        return key
+
+    masked = re.sub(r'<pre[\s\S]*?</pre>|<code[\s\S]*?</code>', mask, html_text, flags=re.DOTALL)
+
+    def try_convert(latex):
+        try:
+            return latex2mathml.converter.convert(latex)
+        except Exception:
+            return None
+
+    # Standalone display math that Markdown wrapped in <p>: replace the whole
+    # paragraph to avoid invalid XHTML like <p><div>...</div></p>
+    def replace_display_paragraph(m):
+        mathml = try_convert(m.group(1))
+        return f'<div class="math-display">{mathml}</div>' if mathml else m.group(0)
+
+    # Remaining $$...$$ (inside phrasing content): use <span> to stay valid
+    def replace_display_inline(m):
+        mathml = try_convert(m.group(1))
+        return f'<span class="math-display">{mathml}</span>' if mathml else m.group(0)
+
+    # Inline $...$
     def replace_inline(m):
-        latex = m.group(1)
-        try:
-            mathml = latex2mathml.converter.convert(latex)
-            return f'<span class="math-inline">{mathml}</span>'
-        except Exception:
-            return m.group(0)
+        mathml = try_convert(m.group(1))
+        return f'<span class="math-inline">{mathml}</span>' if mathml else m.group(0)
 
-    html_text = re.sub(r'\$\$(.*?)\$\$', replace_display, html_text, flags=re.DOTALL)
-    html_text = re.sub(r'(?<!\$)\$(?!\$)(.*?)(?<!\$)\$(?!\$)', replace_inline, html_text, flags=re.DOTALL)
-    return html_text
+    masked = re.sub(r'<p>\s*\$\$(.*?)\$\$\s*</p>', replace_display_paragraph, masked, flags=re.DOTALL)
+    masked = re.sub(r'\$\$(.*?)\$\$', replace_display_inline, masked, flags=re.DOTALL)
+    masked = re.sub(r'(?<!\$)\$(?!\$)(.*?)(?<!\$)\$(?!\$)', replace_inline, masked, flags=re.DOTALL)
+
+    for key, original in placeholders.items():
+        masked = masked.replace(key, original)
+
+    return masked
 
 def get_chapter_XML(work_dir: str, md_filename: str, css_filenames: list[str], content: Optional[str] = None) -> tuple[str, list[str]]:
     """

--- a/modules/mark2epub.py
+++ b/modules/mark2epub.py
@@ -377,7 +377,7 @@ def get_TOCNCX_XML(markdown_filenames, uid="", title=""):
     for i,md_filename in enumerate(markdown_filenames):
         stem = md_filename.split(".")[0]
         src = quote("s{:05d}-{}.xhtml".format(i, stem))
-        toc_ncx += """<navPoint id="navpoint-{}">\n""".format(i)
+        toc_ncx += """<navPoint id="navpoint-{}" playOrder="{}">\n""".format(i, i + 1)
         toc_ncx += """<navLabel>\n<text>{}</text>\n</navLabel>""".format(stem)
         toc_ncx += """<content src="{}"/>""".format(src)
         toc_ncx += """ </navPoint>"""

--- a/modules/mark2epub.py
+++ b/modules/mark2epub.py
@@ -7,9 +7,11 @@ import json
 from PIL import Image
 import regex as re
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 import subprocess
 from typing import Dict, Optional, Tuple
+from urllib.parse import quote
+import latex2mathml.converter
 
 def get_user_input(prompt: str, default: str = "") -> str:
     """Get user input with a default value."""
@@ -73,29 +75,37 @@ def review_markdown(markdown_path: Path) -> tuple[bool, str]:
         else:
             print("Please enter 'y' or 'n'")
 
+def find_image_case_insensitive(images_dir: Path, name: str) -> Optional[Path]:
+    """Find an image file case-insensitively. Returns the actual Path or None."""
+    name_lower = name.lower()
+    try:
+        for entry in images_dir.iterdir():
+            if entry.name.lower() == name_lower:
+                return entry
+    except FileNotFoundError:
+        pass
+    return None
+
 def process_markdown_for_images(markdown_text: str, work_dir: Path) -> tuple[str, list[str]]:
     """Process markdown content to find image references."""
     image_pattern = r'!\[(.*?)\]\((.*?)\)'
     images_found = []
     modified_text = markdown_text
-    
+    images_dir = work_dir / 'images'
+
     for match in re.finditer(image_pattern, markdown_text):
         alt_text, image_path = match.groups()
         image_path = image_path.strip()
         img_path = Path(image_path)
-        if img_path.is_absolute():
-            rel_path = img_path.relative_to(work_dir)
-        else:
-            rel_path = img_path
-            
-        full_image_path = work_dir / 'images' / img_path.name
-        if full_image_path.exists():
-            images_found.append(img_path.name)
-            new_ref = f'![{alt_text}](images/{img_path.name})'
+
+        actual = find_image_case_insensitive(images_dir, img_path.name)
+        if actual is not None:
+            images_found.append(actual.name)
+            new_ref = f'![{alt_text}](images/{actual.name})'
             modified_text = modified_text.replace(match.group(0), new_ref)
         else:
-            print(f"Warning: Image not found: {full_image_path}")
-    
+            print(f"Warning: Image not found: {images_dir / img_path.name}")
+
     return modified_text, images_found
 
 def copy_and_optimize_image(src_path: Path, dest_path: Path, max_dimension: int = 1800) -> None:
@@ -172,11 +182,17 @@ def get_packageOPF_XML(md_filenames=[], image_filenames=[], css_filenames=[], de
     for k,v in description_data["metadata"].items():
         if len(v):
             x = doc.createElement(k)
-            for metadata_type,id_label in [("dc:title","title"),("dc:creator","creator"),("dc:identifier","book-id")]:
+            for metadata_type,id_label in [("dc:title","title"),("dc:creator","creator"),("dc:identifier","pub-id")]:
                 if k==metadata_type:
                     x.setAttribute('id',id_label)
             x.appendChild(doc.createTextNode(v))
             metadata.appendChild(x)
+
+    # Required by EPUB 3: dcterms:modified timestamp
+    modified_meta = doc.createElement('meta')
+    modified_meta.setAttribute('property', 'dcterms:modified')
+    modified_meta.appendChild(doc.createTextNode(datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")))
+    metadata.appendChild(modified_meta)
 
 
     ## Now building the manifest
@@ -207,7 +223,7 @@ def get_packageOPF_XML(md_filenames=[], image_filenames=[], css_filenames=[], de
     for i,md_filename in enumerate(md_filenames):
         x = doc.createElement('item')
         x.setAttribute('id',"s{:05d}".format(i))
-        x.setAttribute('href',"s{:05d}-{}.xhtml".format(i,md_filename.split(".")[0]))
+        x.setAttribute('href', quote("s{:05d}-{}.xhtml".format(i, md_filename.split(".")[0])))
         x.setAttribute('media-type',"application/xhtml+xml")
         manifest.appendChild(x)
 
@@ -249,7 +265,7 @@ def get_packageOPF_XML(md_filenames=[], image_filenames=[], css_filenames=[], de
     x.setAttribute('idref',"titlepage")
     x.setAttribute('linear',"yes")
     spine.appendChild(x)
-    for i,md_filename in enumerate(md_filenames):
+    for i,_ in enumerate(md_filenames):
         x = doc.createElement('itemref')
         x.setAttribute('idref',"s{:05d}".format(i))
         x.setAttribute('linear',"yes")
@@ -338,26 +354,61 @@ def get_TOC_XML(default_css_filenames, markdown_filenames):
     toc_xhtml += """</head>\n<body>\n"""
     toc_xhtml += """<nav epub:type="toc" role="doc-toc" id="toc">\n<h2>Contents</h2>\n<ol epub:type="list">"""
     for i,md_filename in enumerate(markdown_filenames):
-        toc_xhtml += """<li><a href="s{:05d}-{}.xhtml">{}</a></li>""".format(i,md_filename.split(".")[0],md_filename.split(".")[0])
+        stem = md_filename.split(".")[0]
+        href = quote("s{:05d}-{}.xhtml".format(i, stem))
+        toc_xhtml += """<li><a href="{}">{}</a></li>""".format(href, stem)
     toc_xhtml += """</ol>\n</nav>\n</body>\n</html>"""
 
     return toc_xhtml
 
-def get_TOCNCX_XML(markdown_filenames):
+def get_TOCNCX_XML(markdown_filenames, uid="", title=""):
     ## Returns the XML data for the TOC.ncx file
 
     toc_ncx = """<?xml version="1.0" encoding="UTF-8"?>\n"""
-    toc_ncx += """<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" xml:lang="fr" version="2005-1">\n"""
-    toc_ncx += """<head>\n</head>\n"""
+    toc_ncx += """<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" xml:lang="en" version="2005-1">\n"""
+    toc_ncx += """<head>\n"""
+    toc_ncx += """<meta name="dtb:uid" content="{}"/>\n""".format(uid)
+    toc_ncx += """<meta name="dtb:depth" content="1"/>\n"""
+    toc_ncx += """<meta name="dtb:totalPageCount" content="0"/>\n"""
+    toc_ncx += """<meta name="dtb:maxPageNumber" content="0"/>\n"""
+    toc_ncx += """</head>\n"""
+    toc_ncx += """<docTitle><text>{}</text></docTitle>\n""".format(title)
     toc_ncx += """<navMap>\n"""
     for i,md_filename in enumerate(markdown_filenames):
+        stem = md_filename.split(".")[0]
+        src = quote("s{:05d}-{}.xhtml".format(i, stem))
         toc_ncx += """<navPoint id="navpoint-{}">\n""".format(i)
-        toc_ncx += """<navLabel>\n<text>{}</text>\n</navLabel>""".format(md_filename.split(".")[0])
-        toc_ncx += """<content src="s{:05d}-{}.xhtml"/>""".format(i,md_filename.split(".")[0])
+        toc_ncx += """<navLabel>\n<text>{}</text>\n</navLabel>""".format(stem)
+        toc_ncx += """<content src="{}"/>""".format(src)
         toc_ncx += """ </navPoint>"""
     toc_ncx += """</navMap>\n</ncx>"""
 
     return toc_ncx
+
+def convert_math_to_mathml(html_text: str) -> str:
+    """Replace LaTeX math expressions in HTML with inline MathML."""
+    # Display math: $$...$$
+    def replace_display(m):
+        latex = m.group(1)
+        try:
+            mathml = latex2mathml.converter.convert(latex)
+            # Wrap in a block-level span so readers treat it as display math
+            return f'<div class="math-display">{mathml}</div>'
+        except Exception:
+            return m.group(0)
+
+    # Inline math: $...$  (not preceded/followed by another $)
+    def replace_inline(m):
+        latex = m.group(1)
+        try:
+            mathml = latex2mathml.converter.convert(latex)
+            return f'<span class="math-inline">{mathml}</span>'
+        except Exception:
+            return m.group(0)
+
+    html_text = re.sub(r'\$\$(.*?)\$\$', replace_display, html_text, flags=re.DOTALL)
+    html_text = re.sub(r'(?<!\$)\$(?!\$)(.*?)(?<!\$)\$(?!\$)', replace_inline, html_text, flags=re.DOTALL)
+    return html_text
 
 def get_chapter_XML(work_dir: str, md_filename: str, css_filenames: list[str], content: Optional[str] = None) -> tuple[str, list[str]]:
     """
@@ -388,9 +439,12 @@ def get_chapter_XML(work_dir: str, md_filename: str, css_filenames: list[str], c
         extension_configs={"codehilite": {"guess_lang": False}}
     )
 
+    # Convert LaTeX math to MathML for EPUB readers
+    html_text = convert_math_to_mathml(html_text)
+
     # Generate XHTML wrapper
     xhtml = f"""<?xml version="1.0" encoding="UTF-8"?>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:m="http://www.w3.org/1998/Math/MathML" lang="en">
 <head>
     <meta http-equiv="default-style" content="text/html; charset=utf-8"/>
     {''.join(f'<link rel="stylesheet" href="css/{css}" type="text/css" media="all"/>' for css in css_filenames)}
@@ -578,7 +632,11 @@ def main(args):
             )
             
             epub.writestr("OPS/toc.ncx",
-                get_TOCNCX_XML(all_md_filenames),
+                get_TOCNCX_XML(
+                    all_md_filenames,
+                    uid=json_data["metadata"].get("dc:identifier", ""),
+                    title=json_data["metadata"].get("dc:title", "")
+                ),
                 zipfile.ZIP_DEFLATED
             )
 
@@ -590,14 +648,20 @@ def main(args):
                     with open(os.path.join(images_dir, image), "rb") as f:
                         epub.writestr(f"OPS/images/{image}", f.read(), zipfile.ZIP_DEFLATED)
 
-            # Copy CSS files
-            if os.path.exists(css_dir):
-                print(f"Writing {len(all_css_filenames)} CSS files...")
-                for css in all_css_filenames:
-                    css_path = os.path.join(css_dir, css)
-                    if os.path.exists(css_path):
-                        with open(css_path, "rb") as f:
-                            epub.writestr(f"OPS/css/{css}", f.read(), zipfile.ZIP_DEFLATED)
+            # Copy CSS files; write a default style.css for any that are missing
+            default_css_content = b"""body { font-family: serif; line-height: 1.5; margin: 5%; }
+h1, h2, h3, h4, h5, h6 { font-family: sans-serif; }
+img { max-width: 100%; height: auto; }
+pre, code { font-family: monospace; font-size: 0.9em; }
+"""
+            print(f"Writing {len(all_css_filenames)} CSS files...")
+            for css in all_css_filenames:
+                css_path = os.path.join(css_dir, css)
+                if os.path.exists(css_path):
+                    with open(css_path, "rb") as f:
+                        epub.writestr(f"OPS/css/{css}", f.read(), zipfile.ZIP_DEFLATED)
+                else:
+                    epub.writestr(f"OPS/css/{css}", default_css_content, zipfile.ZIP_DEFLATED)
 
         print(f"\nEPUB creation complete: {output_path}")
         

--- a/modules/pdf2md.py
+++ b/modules/pdf2md.py
@@ -91,14 +91,19 @@ def convert_pdf(
 
         models = create_model_dict()
 
-        # Build page_range from start_page / max_pages if provided
+        # Build page_range config. marker-pdf 1.x requires an explicit list of
+        # page indices; there is no "start to end" shorthand. If start_page is
+        # given without max_pages we cannot construct the range without knowing
+        # the document's page count, so we warn and process all pages instead.
         config = {}
-        if start_page is not None or max_pages is not None:
+        if max_pages is not None:
             s = start_page or 0
-            if max_pages is not None:
-                config["page_range"] = list(range(s, s + max_pages))
-            else:
-                config["page_range"] = list(range(s, 10_000))  # open-ended
+            config["page_range"] = list(range(s, s + max_pages))
+        elif start_page is not None:
+            print(
+                f"Warning: --start-page requires --max-pages in marker-pdf 1.x "
+                f"(no open-ended page range is supported). Processing all pages."
+            )
 
         converter = PdfConverter(config=config, artifact_dict=models)
         rendered = converter(input_path)

--- a/modules/pdf2md.py
+++ b/modules/pdf2md.py
@@ -79,54 +79,54 @@ def save_images(images: dict, image_dir: Path) -> None:
 def convert_pdf(
     input_path: str,
     output_dir: Path,
-    batch_multiplier: int = 2,
     max_pages: int = None,
     start_page: int = None,
-    langs: str = None
 ) -> None:
     """
     Convert a single PDF file to markdown format with enhanced image handling.
     """
     try:
-        # Load models
-        from marker.models import load_all_models
-        from marker.convert import convert_single_pdf
-        
-        model_lst = load_all_models()
-        
-        # Convert languages string to list if provided
-        languages = [lang.strip() for lang in langs.split(',')] if langs else None
-        
-        # Convert the PDF
-        full_text, images, metadata = convert_single_pdf(
-            input_path,
-            model_lst,
-            batch_multiplier=batch_multiplier,
-            max_pages=max_pages,
-            start_page=start_page,
-            langs=languages
-        )
-        
+        from marker.models import create_model_dict
+        from marker.converters.pdf import PdfConverter
+
+        models = create_model_dict()
+
+        # Build page_range from start_page / max_pages if provided
+        config = {}
+        if start_page is not None or max_pages is not None:
+            s = start_page or 0
+            if max_pages is not None:
+                config["page_range"] = list(range(s, s + max_pages))
+            else:
+                config["page_range"] = list(range(s, 10_000))  # open-ended
+
+        converter = PdfConverter(config=config, artifact_dict=models)
+        rendered = converter(input_path)
+
+        full_text = rendered.markdown
+        images = rendered.images
+        metadata = rendered.metadata
+
         # All output will go to the output directory
         output_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Save markdown content
         md_output = output_dir / f"{Path(input_path).stem}.md"
         md_output.write_text(full_text, encoding='utf-8')
         print(f"Markdown saved to: {md_output}")
-        
+
         # Save metadata as JSON
         meta_output = output_dir / f"{Path(input_path).stem}_metadata.json"
         with open(meta_output, 'w', encoding='utf-8') as f:
             json.dump(metadata, f, indent=2)
         print(f"Metadata saved to: {meta_output}")
-        
+
         # Enhanced image handling
         try:
             if images:
                 image_dir = output_dir / "images"
                 save_images(images, image_dir)
-                
+
                 # Cleanup PIL Images
                 for img in images.values():
                     if isinstance(img, Image.Image):
@@ -134,10 +134,10 @@ def convert_pdf(
                             img.close()
                         except Exception as e:
                             print(f"Warning: Failed to close image: {e}")
-                images.clear()  # Clear the dictionary to help with cleanup
+                images.clear()
         except Exception as e:
             print(f"Warning: Error during image cleanup: {e}")
-            
+
     except Exception as e:
         print(f"Error converting {input_path}: {str(e)}", file=sys.stderr)
         sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-marker-pdf==0.3.10
-transformers==4.45.2
-markdown==3.7
+marker-pdf==1.10.2
+transformers==4.57.6
+markdown==3.10.2
+latex2mathml==3.79.0


### PR DESCRIPTION
## Summary

- **Closes #9, #1** — `OPS/css/style.css` missing from EPUB: now writes a default stylesheet when none exists on disk; also fixes four additional `epubcheck` errors: `unique-identifier` mismatch (`book-id` → `pub-id`), missing `dcterms:modified` meta, spaces in filenames producing invalid URIs, and malformed `toc.ncx` (missing `<docTitle>` and `<meta>` elements)
- **Closes #6, #1** — Images not found in EPUB: replaced case-sensitive file lookup with a case-insensitive scan so `0_Image_0.Png` in markdown correctly resolves to `0_image_0.png` on Linux; `images/` prefix is now always correctly applied
- **Closes #3** — LaTeX rendered as raw text: added `convert_math_to_mathml()` using `latex2mathml` to convert `$$...$$` and `$...$` to inline MathML before writing XHTML chapters — no JavaScript required
- **Issue #5** (upstream marker-pdf crash) — not directly fixable here, but upgrading marker-pdf to 1.10.2 may resolve the logits/bboxes mismatch as a side-effect of the library rewrite

## Dependency upgrades

| Package | Before | After | Notes |
|---|---|---|---|
| `marker-pdf` | 0.3.10 | 1.10.2 | Major API rewrite (see below) |
| `transformers` | 4.45.2 | 4.57.6 | Latest compatible; marker-pdf 1.x pins `<5.0.0` |
| `markdown` | 3.7 | 3.10.2 | |
| `latex2mathml` | — | 3.79.0 | New dependency for math rendering |

## Breaking change: marker-pdf 1.x API migration

`pdf2md.py` and `main.py` updated accordingly:

- `load_all_models()` → `create_model_dict()`
- `convert_single_pdf(path, models, ...)` → `PdfConverter(config, artifact_dict=models)(path)`
- Return value `(text, images, metadata)` → `rendered.markdown` / `.images` / `.metadata`
- `start_page` / `max_pages` mapped to `page_range` config list
- `--batch-multiplier` and `--langs` CLI flags removed (automatic in 1.x)

## Test plan

- [ ] Convert a PDF with mixed-case image filenames and verify images appear correctly in the EPUB
- [ ] Run `epubcheck` on a generated EPUB and confirm zero errors
- [ ] Convert a PDF containing LaTeX math and verify MathML renders in an EPUB reader
- [ ] Verify `OPS/css/style.css` is present in the EPUB archive
- [ ] Run `pip install -r requirements.txt` in a clean environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LaTeX math is now converted to MathML in generated EPUBs.

* **Improvements**
  * Image references resolved case-insensitively; missing-image warnings improved.
  * EPUB metadata includes modification timestamps and updated identifier mapping.
  * Chapter, TOC and image links in EPUB are URL-encoded.
  * CSS fallback content is used when referenced styles are missing.
  * Dependency updates include a LaTeX-to-MathML library.

* **Changes**
  * Removed --batch-multiplier and --langs CLI options; PDF conversion page-range handling refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->