### PR TITLE
Fix invalid media-type for .jpeg images in the OPF manifest

### DIFF
--- a/modules/mark2epub.py
+++ b/modules/mark2epub.py
@@ -231,13 +231,12 @@ def get_packageOPF_XML(md_filenames=[], image_filenames=[], css_filenames=[], de
         x = doc.createElement('item')
         x.setAttribute('id',"image-{:05d}".format(i))
         x.setAttribute('href', "images/{}".format(quote(image_filename)))
-        if "gif" in image_filename:
+        ext = Path(image_filename).suffix.lower()
+        if ext == '.gif':
             x.setAttribute('media-type',"image/gif")
-        elif "jpg" in image_filename:
+        elif ext in ['.jpg', '.jpeg']:
             x.setAttribute('media-type',"image/jpeg")
-        elif "jpeg" in image_filename:
-            x.setAttribute('media-type',"image/jpg")
-        elif "png" in image_filename:
+        elif ext == '.png':
             x.setAttribute('media-type',"image/png")
         if image_filename==description_data["cover_image"]:
             x.setAttribute('properties',"cover-image")


### PR DESCRIPTION
get_packageOPF_XML assigned media-type="image/jpg" to .jpeg images. "image/jpg" is not a registered MIME type; the correct value is "image/jpeg". Because "jpg" is not a substring of "jpeg", .jpg files matched the preceding branch and were labelled correctly, so only .jpeg files were affected. marker emits .jpeg for extracted figures, so in practice every image in a generated EPUB carried an invalid media type.

Replace the substring matching with extension matching on Path.suffix, mirroring update_package_manifest in this same file, which already maps both .jpg and .jpeg to image/jpeg. This also avoids false matches on filenames that merely contain "png" or "gif" outside the extension.

Verified by rebuilding an EPUB whose figures are .jpeg: the OPF manifest now declares image/jpeg for every image, and the archive still passes structural checks (uncompressed mimetype first, valid zip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image format detection when generating EPUB files.
  * Correctly identifies GIF, JPEG, and PNG images, including proper JPEG media-type metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->