### PR TITLE
Exit non-zero when a PDF fails to convert

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import sys
 from pathlib import Path
 import modules.pdf2md as pdf2md
 import modules.mark2epub as mark2epub
@@ -63,6 +64,7 @@ def main():
     print(f"Found {len(queue)} PDF files to process")
     
     # Process each PDF
+    failed = []
     for pdf_path in queue:
         print(f"\nProcessing: {pdf_path.name}")
         
@@ -78,7 +80,8 @@ def main():
             # Check if markdown directory exists when skipping MD generation
             if args.skip_md:
                 if not markdown_dir.exists():
-                    print(f"Error: Markdown directory not found: {markdown_dir}")
+                    print(f"Error: Markdown directory not found: {markdown_dir}", file=sys.stderr)
+                    failed.append(pdf_path.name)
                     continue
                 print(f"Using existing markdown files from: {markdown_dir}")
                 
@@ -98,8 +101,18 @@ def main():
                 mark2epub.convert_to_epub(markdown_dir, output_path)
                 
         except Exception as e:
-            print(f"Error processing {pdf_path.name}: {str(e)}")
+            print(f"Error processing {pdf_path.name}: {str(e)}", file=sys.stderr)
+            failed.append(pdf_path.name)
             continue
+
+    if failed:
+        print(
+            f"\nFailed to process {len(failed)} of {len(queue)} PDF file(s):",
+            file=sys.stderr,
+        )
+        for name in failed:
+            print(f"  - {name}", file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()

--- a/modules/pdf2md.py
+++ b/modules/pdf2md.py
@@ -145,7 +145,7 @@ def convert_pdf(
 
     except Exception as e:
         print(f"Error converting {input_path}: {str(e)}", file=sys.stderr)
-        sys.exit(1)
+        raise
 
     
 def add_pdfs_to_queue(input_path: Path) -> list[Path]:


### PR DESCRIPTION
A failed conversion does not reach the caller. Depending on where it fails, the
process either **exits 0 having produced nothing**, or **silently abandons the
rest of the queue**. Anything scripting this tool — a shell pipeline, a
Makefile, CI — cannot tell that anything went wrong.

Two distinct bugs produce this, and they need fixing together.

## 1. `main()` never exits non-zero

`main()` wraps each PDF in `except Exception`, prints the error, and continues.
There is no `sys.exit`, so a run that produced no EPUB still reports success.
The missing-markdown-directory branch under `--skip-md` had the same shape: it
printed `Error:` and continued.

I hit this for real. A run failed during EPUB generation, produced no `.epub`,
and exited 0.

## 2. `convert_pdf` exits instead of raising, bypassing that handler entirely

`convert_pdf` caught every exception, printed it, and called `sys.exit(1)`.
`SystemExit` inherits from `BaseException`, **not** `Exception` — so the
`except Exception` around the call site never saw it. A single unreadable PDF
terminated the process immediately: remaining files in the queue were never
attempted, and no summary was printed.

This is the more common failure path of the two, since it covers any PDF that
marker cannot parse.

## The fix

- `convert_pdf` re-raises instead of exiting. A bare `raise` preserves the
  original traceback and exception context.
- `main()` records each failed PDF, prints errors to `stderr` rather than
  `stdout`, and after the queue is drained prints a summary and exits 1 if
  anything failed.

Processing still continues past a failure, so one bad file in a batch does not
abort the rest. That behaviour looked deliberate and is preserved — bug 2 was
silently defeating it.

The `sys.exit` calls in `add_pdfs_to_queue` are deliberately left alone. They
validate arguments before the queue is built, where there is no in-flight file
to record and nothing to continue to.

## Verification

| scenario | before | after |
| --- | --- | --- |
| PDF unreadable by marker | exit 1, **rest of queue skipped, no summary** | exit 1, queue completes, summary |
| batch of 2 unreadable PDFs | 1 error printed, no summary | 2 errors printed, summary lists both |
| EPUB generation fails | exit 0 | exit 1 |
| `--skip-md`, markdown dir missing | exit 0 | exit 1 |
| batch: 1 failure + 1 success | exit 0 | exit 1, success still processed |
| fully successful run | exit 0 | exit 0, stderr empty, valid EPUB |

Each row was run against the working tree. The last row matters most: a careless
fix here exits 1 unconditionally.
