### PR TITLE
Bump latex2mathml to 3.81.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 marker-pdf==1.10.2
 transformers==4.57.6
 markdown==3.10.2
-latex2mathml==3.79.0
+latex2mathml==3.81.0


### PR DESCRIPTION
Updates the only dependency with a newer release available.

- latex2mathml 3.79.0 → 3.81.0
- marker-pdf 1.10.2, markdown 3.10.2: already latest
- transformers 4.57.6: latest allowed — marker-pdf constrains `transformers<5.0.0`, so 5.x is blocked until marker-pdf lifts the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the LaTeX-to-MathML conversion dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->