### PR TITLE
Add CI workflow, dependabot config; fix lint findings and README drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Syntax check
+        run: python -m compileall -q main.py modules/
+
+      - name: Install ruff
+        run: pip install ruff
+
+      # E9/F: syntax errors and definite bugs (undefined names, unused
+      # imports). Style rules are deliberately excluded.
+      - name: Lint
+        run: ruff check --select E9,F .

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Convert PDF files to nicely structured Markdown and EPUB format with intelligent
 - marker-pdf==1.10.2
 - transformers==4.57.6
 - markdown==3.10.2
-- latex2mathml==3.79.0
+- latex2mathml==3.81.0
 
 ### ⚠️ Python version
 
@@ -149,7 +149,7 @@ Please ensure your code follows the existing style and includes appropriate test
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/yourusername/pdf2epub.git
+git clone https://github.com/overcuriousity/pdf2epub.git
 cd pdf2epub
 ```
 

--- a/modules/mark2epub.py
+++ b/modules/mark2epub.py
@@ -9,7 +9,7 @@ import regex as re
 from pathlib import Path
 from datetime import datetime, timezone
 import subprocess
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 from urllib.parse import quote
 from xml.sax.saxutils import escape as xml_escape
 import latex2mathml.converter
@@ -487,9 +487,6 @@ def convert_to_epub(markdown_dir: Path, output_path: Path) -> None:
     if not list(markdown_dir.glob('*.md')):
         raise ValueError(f"No markdown files found in: {markdown_dir}")
     
-    # Set up mark2epub's working directory
-    work_dir = str(markdown_dir)
-    
     # Generate EPUB file
     epub_path = markdown_dir / f"{markdown_dir.name}.epub"
     main([str(markdown_dir), str(epub_path)])
@@ -684,7 +681,7 @@ pre, code { font-family: monospace; font-size: 0.9em; }
 
         print(f"\nEPUB creation complete: {output_path}")
         
-    except Exception as e:
+    except Exception:
         import traceback
         print(f"Error processing {work_dir}:")
         print(traceback.format_exc())

--- a/modules/pdf2md.py
+++ b/modules/pdf2md.py
@@ -1,8 +1,6 @@
-import argparse
 from pathlib import Path
 import sys
 import json
-import marker 
 from PIL import Image
 import io
 
@@ -101,8 +99,8 @@ def convert_pdf(
             config["page_range"] = list(range(s, s + max_pages))
         elif start_page is not None:
             print(
-                f"Warning: --start-page requires --max-pages in marker-pdf 1.x "
-                f"(no open-ended page range is supported). Processing all pages."
+                "Warning: --start-page requires --max-pages in marker-pdf 1.x "
+                "(no open-ended page range is supported). Processing all pages."
             )
 
         converter = PdfConverter(config=config, artifact_dict=models)

--- a/modules/postprocessing/template.py
+++ b/modules/postprocessing/template.py
@@ -24,7 +24,7 @@ Send ONLY the python script content back to the user. your answer should exclusi
 
 import re
 from pathlib import Path
-from typing import List, Tuple, Dict
+from typing import List
 import logging
 
 # Configure logging


### PR DESCRIPTION
Brings the repo up to standard GitHub hygiene ahead of the first release.

## CI (`.github/workflows/ci.yml`)
- Runs on pushes and PRs to `main`, Python 3.10–3.13 matrix.
- `compileall` syntax check + `ruff check --select E9,F` (syntax errors and definite bugs only — no style enforcement).
- Runtime deps (torch, marker models) deliberately not installed: multi-GB, and there is no test suite to exercise them.

## Dependabot (`.github/dependabot.yml`)
- Weekly update PRs for pip and github-actions ecosystems.

## Lint fixes
All 9 existing ruff E9/F findings fixed so CI starts green: unused imports (`argparse`, `marker`, `typing.Tuple`/`Dict`), dead `work_dir` local in `convert_to_epub`, unused exception binding, two placeholder-less f-strings. No behavior change; verified with `compileall` + clean ruff run.

## README
- `latex2mathml` 3.79.0 → 3.81.0 (drifted after #17)
- Clone URL: `yourusername` placeholder → `overcuriousity/pdf2epub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions with the correct repository URL.
  * Updated the documented `latex2mathml` version.

* **Chores**
  * Added weekly automated checks for Python and workflow dependencies.
  * Added continuous integration checks across Python 3.10–3.13, including syntax and lint validation.

* **Refactor**
  * Removed unused imports and simplified internal error handling without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->